### PR TITLE
fix(modifiers): update expression generation

### DIFF
--- a/src/expression-modifiers/accumulation/__tests__/index.spec.js
+++ b/src/expression-modifiers/accumulation/__tests__/index.spec.js
@@ -90,7 +90,7 @@ describe('accumulation', () => {
                 expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
               });
 
-              expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0), 0), 0, RowNo()))');
+              expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0), 0), 0, RowNo()))');
             });
 
             it('should generate correct expression when dimension is non-numeric', () => {
@@ -98,7 +98,7 @@ describe('accumulation', () => {
                 expression, modifier, properties, libraryItemsProps,
               });
 
-              expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0), 0), 0, RowNo()))');
+              expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0), 0), 0, RowNo()))');
             });
           });
 
@@ -131,7 +131,7 @@ describe('accumulation', () => {
                 expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
               });
 
-              expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0), 0), 0, 6))');
+              expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0), 0), 0, 6))');
             });
 
             it('should generate correct expression when dimension is non-numeric', () => {
@@ -139,7 +139,7 @@ describe('accumulation', () => {
                 expression, modifier, properties, libraryItemsProps,
               });
 
-              expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0), 0), 0, 6))');
+              expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0), 0), 0, 6))');
             });
           });
 
@@ -190,7 +190,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo(Total))), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo(Total))), dim2, dim1))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -198,7 +198,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo(Total))), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo(Total))), dim2, dim1))');
                 });
               });
 
@@ -212,7 +212,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, RowNo(Total))), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, RowNo(Total))), dim2, dim1)');
                 });
               });
             });
@@ -232,7 +232,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6)), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6)), dim2, dim1))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -240,7 +240,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6)), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6)), dim2, dim1))');
                 });
               });
 
@@ -254,7 +254,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, 6)), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, 6)), dim2, dim1)');
                 });
               });
             });
@@ -280,7 +280,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo())), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo())), dim2, dim1))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -288,7 +288,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo())), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo())), dim2, dim1))');
                 });
               });
 
@@ -302,7 +302,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, RowNo())), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, RowNo())), dim2, dim1)');
                 });
               });
             });
@@ -322,7 +322,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6)), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6)), dim2, dim1))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -330,7 +330,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6)), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6)), dim2, dim1))');
                 });
               });
 
@@ -344,7 +344,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, 6)), [dim2], [dim1])');
+                  expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, 6)), dim2, dim1)');
                 });
               });
             });
@@ -376,7 +376,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo(Total)))');
+                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo(Total)))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -384,7 +384,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo(Total)))');
+                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo(Total)))');
                 });
               });
 
@@ -418,7 +418,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6))');
+                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -426,7 +426,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6))');
+                  expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6))');
                 });
               });
 
@@ -466,7 +466,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo()))');
+                  expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo()))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -474,7 +474,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo()))');
+                  expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo()))');
                 });
               });
 
@@ -508,7 +508,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6))');
+                  expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6))');
                 });
 
                 it('should generate correct expression when dimension is non-numeric', () => {
@@ -516,7 +516,7 @@ describe('accumulation', () => {
                     expression, modifier, properties, libraryItemsProps,
                   });
 
-                  expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6))');
+                  expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6))');
                 });
               });
 
@@ -547,7 +547,7 @@ describe('accumulation', () => {
 
     describe('One dimension', () => {
       beforeEach(() => {
-        properties.qHyperCubeDef.qDimensions = [dim1];
+        properties.qHyperCubeDef.qDimensions = dim1;
       });
 
       describe('Normal dimension', () => {

--- a/src/expression-modifiers/accumulation/index.js
+++ b/src/expression-modifiers/accumulation/index.js
@@ -49,7 +49,10 @@ export default {
       const dim1Comp = helper.getDimComp(dimensions, 1, libraryItemsProps);
       const dim2Comp = helper.getDimComp(dimensions, 0, libraryItemsProps);
       const aggrComp = helper.getAggrComp(generatedExpression, dim1Comp, dim2Comp);
-      generatedExpression = aggrComp;
+      generatedExpression = !modifier.showExcludedValues ? aggrComp
+        : helper.getExcludedComp({
+          modifier, dimensions, libraryItemsProps, dimensionAndFieldList, valueComp: aggrComp,
+        });
     }
     return generatedExpression;
   },

--- a/src/expression-modifiers/difference/__tests__/index.spec.js
+++ b/src/expression-modifiers/difference/__tests__/index.spec.js
@@ -82,7 +82,7 @@ describe('difference', () => {
             expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
           });
 
-          expect(outputExpression).to.equal('If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0), 0) - Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0), 0))');
+          expect(outputExpression).to.equal('If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0), 0) - Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0), 0))');
         });
 
         it('should generate correct expression when dimension is non-numeric', () => {
@@ -90,7 +90,7 @@ describe('difference', () => {
             expression, modifier, properties, libraryItemsProps,
           });
 
-          expect(outputExpression).to.equal('If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0), 0) - Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0), 0))');
+          expect(outputExpression).to.equal('If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0), 0) - Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0), 0))');
         });
       });
 
@@ -133,7 +133,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('Aggr(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0) - Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0)), [dim2], [dim1])');
+                expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0) - Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0)), dim2, dim1))');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -141,7 +141,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('Aggr(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0) - Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0)), [dim2], [dim1])');
+                expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0) - Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0)), dim2, dim1))');
               });
             });
 
@@ -155,7 +155,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('Aggr( (　Sum(Sales)　)  - Above(Total  (　Sum(Sales)　) ), [dim2], [dim1])');
+                expect(outputExpression).to.equal('Aggr( (　Sum(Sales)　)  - Above(Total  (　Sum(Sales)　) ), dim2, dim1)');
               });
             });
           });
@@ -175,7 +175,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('Aggr(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0) - Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0)), [dim2], [dim1])');
+                expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0) - Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0)), dim2, dim1))');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -183,7 +183,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('Aggr(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0) - Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0)), [dim2], [dim1])');
+                expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0) - Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0)), dim2, dim1))');
               });
             });
 
@@ -197,7 +197,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('Aggr( (　Sum(Sales)　)  - Above( (　Sum(Sales)　) ), [dim2], [dim1])');
+                expect(outputExpression).to.equal('Aggr( (　Sum(Sales)　)  - Above( (　Sum(Sales)　) ), dim2, dim1)');
               });
             });
           });
@@ -223,7 +223,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0) - Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0))');
+                expect(outputExpression).to.equal('If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0) - Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0))');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -231,7 +231,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0) - Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0))');
+                expect(outputExpression).to.equal('If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0) - Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0))');
               });
             });
 
@@ -265,7 +265,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0) - Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0))');
+                expect(outputExpression).to.equal('If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0) - Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0))');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -273,7 +273,7 @@ describe('difference', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0) - Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0))');
+                expect(outputExpression).to.equal('If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0) - Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0))');
               });
             });
 
@@ -299,7 +299,7 @@ describe('difference', () => {
   describe('extractExpression', () => {
     describe('One dimension', () => {
       beforeEach(() => {
-        properties.qHyperCubeDef.qDimensions = [dim1];
+        properties.qHyperCubeDef.qDimensions = dim1;
       });
 
       describe('showExcludedValues = true', () => {

--- a/src/expression-modifiers/difference/index.js
+++ b/src/expression-modifiers/difference/index.js
@@ -48,7 +48,10 @@ export default {
       const dim1Comp = helper.getDimComp(dimensions, 1, libraryItemsProps);
       const dim2Comp = helper.getDimComp(dimensions, 0, libraryItemsProps);
       const aggrComp = helper.getAggrComp(generatedExpression, dim1Comp, dim2Comp);
-      generatedExpression = aggrComp;
+      generatedExpression = !modifier.showExcludedValues ? aggrComp
+        : helper.getExcludedComp({
+          modifier, dimensions, libraryItemsProps, dimensionAndFieldList, funcComp: 'Only', valueComp: aggrComp,
+        });
     }
     return generatedExpression;
   },

--- a/src/expression-modifiers/moving-average/__tests__/index.spec.js
+++ b/src/expression-modifiers/moving-average/__tests__/index.spec.js
@@ -95,7 +95,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0), 0), 0, RowNo())) / RowNo()');
+                expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0), 0), 0, RowNo())) / RowNo()');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -103,7 +103,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0), 0), 0, RowNo())) / RowNo()');
+                expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0), 0), 0, RowNo())) / RowNo()');
               });
             });
 
@@ -116,7 +116,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0)), 0, RowNo()))');
+                expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0)), 0, RowNo()))');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -124,7 +124,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0)), 0, RowNo()))');
+                expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0)), 0, RowNo()))');
               });
             });
           });
@@ -181,7 +181,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
+                expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -189,7 +189,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
+                expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
               });
             });
 
@@ -202,7 +202,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                 });
 
-                expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"}>}0)), 0, 6))');
+                expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"}>}0)), 0, 6))');
               });
 
               it('should generate correct expression when dimension is non-numeric', () => {
@@ -210,7 +210,7 @@ describe('moving average', () => {
                   expression, modifier, properties, libraryItemsProps,
                 });
 
-                expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"}>}0)), 0, 6))');
+                expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"}>}0)), 0, 6))');
               });
             });
           });
@@ -285,7 +285,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo(Total))) / RowNo(Total), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo(Total))) / RowNo(Total), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -293,7 +293,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo(Total))) / RowNo(Total), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo(Total))) / RowNo(Total), dim2, dim1))');
                   });
                 });
 
@@ -306,7 +306,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, RowNo(Total))), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, RowNo(Total))), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -314,7 +314,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, RowNo(Total))), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, RowNo(Total))), dim2, dim1))');
                   });
                 });
               });
@@ -333,7 +333,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, RowNo(Total))) / RowNo(Total), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, RowNo(Total))) / RowNo(Total), dim2, dim1)');
                   });
                 });
 
@@ -346,7 +346,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total  (　Sum(Sales)　) , 0, RowNo(Total))), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total  (　Sum(Sales)　) , 0, RowNo(Total))), dim2, dim1)');
                   });
                 });
               });
@@ -371,7 +371,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total)), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -379,7 +379,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total)), dim2, dim1))');
                   });
                 });
 
@@ -392,7 +392,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, 6)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, 6)), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -400,7 +400,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, 6)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, 6)), dim2, dim1))');
                   });
                 });
               });
@@ -419,7 +419,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, 6)) / RangeMin(6, RowNo(Total)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(Total  (　Sum(Sales)　) , 0, 6)) / RangeMin(6, RowNo(Total)), dim2, dim1)');
                   });
                 });
 
@@ -432,7 +432,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total  (　Sum(Sales)　) , 0, 6)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(Total  (　Sum(Sales)　) , 0, 6)), dim2, dim1)');
                   });
                 });
               });
@@ -463,7 +463,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo())) / RowNo(), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo())) / RowNo(), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -471,7 +471,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo())) / RowNo(), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo())) / RowNo(), dim2, dim1))');
                   });
                 });
 
@@ -484,7 +484,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, RowNo())), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, RowNo())), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -492,7 +492,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, RowNo())), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, RowNo())), dim2, dim1))');
                   });
                 });
               });
@@ -511,7 +511,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, RowNo())) / RowNo(), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, RowNo())) / RowNo(), dim2, dim1)');
                   });
                 });
 
@@ -524,7 +524,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above( (　Sum(Sales)　) , 0, RowNo())), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above( (　Sum(Sales)　) , 0, RowNo())), dim2, dim1)');
                   });
                 });
               });
@@ -549,7 +549,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo()), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo()), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -557,7 +557,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo()), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo()), dim2, dim1))');
                   });
                 });
 
@@ -570,7 +570,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, 6)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}Aggr(RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, 6)), dim2, dim1))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -578,7 +578,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, 6)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Only({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}Aggr(RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, 6)), dim2, dim1))');
                   });
                 });
               });
@@ -597,7 +597,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, 6)) / RangeMin(6, RowNo()), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeSum(Above( (　Sum(Sales)　) , 0, 6)) / RangeMin(6, RowNo()), dim2, dim1)');
                   });
                 });
 
@@ -610,7 +610,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above( (　Sum(Sales)　) , 0, 6)), [dim2], [dim1])');
+                    expect(outputExpression).to.equal('Aggr(RangeAvg(Above( (　Sum(Sales)　) , 0, 6)), dim2, dim1)');
                   });
                 });
               });
@@ -647,7 +647,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo(Total))) / RowNo(Total)');
+                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo(Total))) / RowNo(Total)');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -655,7 +655,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo(Total))) / RowNo(Total)');
+                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo(Total))) / RowNo(Total)');
                   });
                 });
 
@@ -668,7 +668,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, RowNo(Total)))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, RowNo(Total)))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -676,7 +676,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, RowNo(Total)))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, RowNo(Total)))');
                   });
                 });
               });
@@ -733,7 +733,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total))');
+                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -741,7 +741,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total))');
+                    expect(outputExpression).to.equal('RangeSum(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo(Total))');
                   });
                 });
 
@@ -754,7 +754,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, 6))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, 6))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -762,7 +762,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, 6))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(Total If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, 6))');
                   });
                 });
               });
@@ -825,7 +825,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, RowNo())) / RowNo()');
+                    expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, RowNo())) / RowNo()');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -833,7 +833,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, RowNo())) / RowNo()');
+                    expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, RowNo())) / RowNo()');
                   });
                 });
 
@@ -846,7 +846,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, RowNo()))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, RowNo()))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -854,7 +854,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, RowNo()))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, RowNo()))');
                   });
                 });
               });
@@ -911,7 +911,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
+                    expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -919,7 +919,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeSum(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
+                    expect(outputExpression).to.equal('RangeSum(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0), 0), 0, 6)) / RangeMin(6, RowNo())');
                   });
                 });
 
@@ -932,7 +932,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps, dimensionAndFieldList,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={">=$(=Min([dim1]))<=$(=Max([dim1]))"},[dim2]={">=$(=Min([dim2]))<=$(=Max([dim2]))"}>}0)), 0, 6))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={">=$(=Min(dim1))<=$(=Max(dim1))"},dim2={">=$(=Min(dim2))<=$(=Max(dim2))"}>}0)), 0, 6))');
                   });
 
                   it('should generate correct expression when dimension is non-numeric', () => {
@@ -940,7 +940,7 @@ describe('moving average', () => {
                       expression, modifier, properties, libraryItemsProps,
                     });
 
-                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count([dim1]) * Count([dim2]) > 0,  (　Sum(Sales)　)  + Sum({1<[dim1]={"=Only({1}[dim1])>=\'$(=MinString([dim1]))\' and Only({1}[dim1])<=\'$(=MaxString([dim1]))\'"},[dim2]={"=Only({1}[dim2])>=\'$(=MinString([dim2]))\' and Only({1}[dim2])<=\'$(=MaxString([dim2]))\'"}>}0)), 0, 6))');
+                    expect(outputExpression).to.equal('RangeAvg(Above(If(Count(dim1) * Count(dim2) > 0,  (　Sum(Sales)　)  + Sum({1<dim1={"=Only({1}dim1)>=\'$(=MinString(dim1))\' and Only({1}dim1)<=\'$(=MaxString(dim1))\'"},dim2={"=Only({1}dim2)>=\'$(=MinString(dim2))\' and Only({1}dim2)<=\'$(=MaxString(dim2))\'"}>}0)), 0, 6))');
                   });
                 });
               });
@@ -991,7 +991,7 @@ describe('moving average', () => {
 
     describe('One dimension', () => {
       beforeEach(() => {
-        properties.qHyperCubeDef.qDimensions = [dim1];
+        properties.qHyperCubeDef.qDimensions = dim1;
       });
 
       describe('Normal dimension', () => {

--- a/src/expression-modifiers/moving-average/index.js
+++ b/src/expression-modifiers/moving-average/index.js
@@ -69,7 +69,10 @@ export default {
       const dim1Comp = helper.getDimComp(dimensions, 1, libraryItemsProps);
       const dim2Comp = helper.getDimComp(dimensions, 0, libraryItemsProps);
       const aggrComp = helper.getAggrComp(generatedExpression, dim1Comp, dim2Comp);
-      generatedExpression = aggrComp;
+      generatedExpression = !modifier.showExcludedValues ? aggrComp
+        : helper.getExcludedComp({
+          modifier, dimensions, libraryItemsProps, dimensionAndFieldList, funcComp: 'Only', valueComp: aggrComp,
+        });
     }
     return generatedExpression;
   },


### PR DESCRIPTION
This PR is to update expression generation for moving-average and difference in case of:
1. two dimensions, and
2. the primary dimension is the first dimension, and
3. showExcludedValues = true

It also fixes the issues where there is comment in dimension or measure definition or dimension using square brackets.