### PR TITLE
fix(normalization): remove show excluded checkbox

### DIFF
--- a/src/expression-modifiers/normalization/properties.js
+++ b/src/expression-modifiers/normalization/properties.js
@@ -115,13 +115,6 @@ export default function (rootPath, translationKeys = {}) {
               return handler.layout.qHyperCube.qDimensionInfo.length > 1;
             },
           },
-          showExcludedValues: {
-            refFn: data => `${getRef(data, rootPath)}.showExcludedValues`,
-            type: 'boolean',
-            translation: translationKeys.showExcludedValues || 'properties.modifier.showExcludedValues',
-            schemaIgnore: true,
-            defaultValue: true,
-          },
         },
         show(itemData, handler) {
           return helper.isApplicable({ properties: handler.properties });


### PR DESCRIPTION
Normalization of a dimension value does not depend on other dimension values and the order of dimension values. So we don't need to have the option "Show excluded" as other modifiers which use range functions.