### PR TITLE
fix(normalization): remove options not needed for normalization

### DIFF
--- a/src/expression-modifiers/normalization/_tests_/index.spec.js
+++ b/src/expression-modifiers/normalization/_tests_/index.spec.js
@@ -26,9 +26,6 @@ describe('normalization', () => {
       disabled: false,
       primaryDimension: 0,
       relativeNumbers: 0,
-      crossAllDimensions: false,
-      showExcludedValues: true,
-      fullNormalization: false,
       outputExpression: '',
     };
     expression = 'Sum([Sales])';

--- a/src/expression-modifiers/normalization/index.js
+++ b/src/expression-modifiers/normalization/index.js
@@ -7,9 +7,6 @@ const DEFAULT_OPTIONS = {
   disabled: false,
   primaryDimension: 0,
   relativeNumbers: 0,
-  crossAllDimensions: false,
-  showExcludedValues: true,
-  fullNormalization: false,
   outputExpression: '',
 };
 
@@ -41,7 +38,7 @@ function getSumDisregardSelec(expression) {
 export default {
   translationKey: 'properties.modifier.normalization',
 
-  needDimension: helper.needDimension,
+  needDimension: () => true,
 
   isApplicable({ properties, layout }) {
     return helper.isApplicable({

--- a/src/expression-modifiers/normalization/properties.js
+++ b/src/expression-modifiers/normalization/properties.js
@@ -6,6 +6,7 @@ const NORMALIZATION_TYPES = {
   RELATIVE_TO_TOTAL_SELECTION: 0,
   RELATIVE_TO_DIM_UNIVERSE: 1,
   RELATIVE_TO_TOTAL_UNIVERSE: 2,
+  RELATIVE_TO_TOTAL_WITHIN_GROUP: 3,
 };
 
 function getModifierIndex(measure, modifiersRef) {
@@ -72,7 +73,9 @@ export default function (rootPath, translationKeys = {}) {
               })); // To avoid depending on the layout, we use the first dimension in the drill down dimension
             },
             show(itemData, handler) {
-              return handler.layout.qHyperCube.qDimensionInfo.length > 1;
+              const modifier = getModifier(itemData, rootPath);
+              const { relativeNumbers } = modifier;
+              return relativeNumbers === NORMALIZATION_TYPES.RELATIVE_TO_TOTAL_WITHIN_GROUP && handler.layout.qHyperCube.qDimensionInfo.length > 1;
             },
           },
           relativeNumbers: {
@@ -100,20 +103,6 @@ export default function (rootPath, translationKeys = {}) {
                 translation: translationKeys.relativeNumbersTotalUniverse || 'properties.modifier.relativeNumbers.total.universe',
               },
             ],
-          },
-          crossAllDimensions: {
-            refFn: data => `${getRef(data, rootPath)}.crossAllDimensions`,
-            type: 'boolean',
-            translation: translationKeys.crossAllDimensions || 'properties.modifier.crossAllDimensions',
-            title: {
-              translation:
-              translationKeys.crossAllDimensionsTooltip || 'properties.modifier.normalization.crossAllDimensions.tooltip',
-            },
-            schemaIgnore: true,
-            defaultValue: false,
-            show(itemData, handler) {
-              return handler.layout.qHyperCube.qDimensionInfo.length > 1;
-            },
           },
         },
         show(itemData, handler) {


### PR DESCRIPTION
Remove the following things which are not appropriate to normalization:
- Cross dimension check box
- Disclaimer about sorting
- Dimension drop-down for the first three relative numbers cases