### PR TITLE
chore: remove incorrect module field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "node": ">=8"
   },
   "main": "dist/qlik-modifiers.js",
-  "module": "dist/qlik-modifiers.esm.js",
   "scripts": {
     "build": "webpack --config ./webpack.config.js",
     "lint": "eslint src",


### PR DESCRIPTION
Removing the module field from package.json because the file `qlik-modifiers.esm.js` doesn't exist, causing build problems in some cases (when building with rollup for instance).