### PR TITLE
fix: ignore missing master items

### DIFF
--- a/src/master-item-subscriber.js
+++ b/src/master-item-subscriber.js
@@ -61,7 +61,7 @@ export default function MasterItemSubscriber({ model, callback }) {
         enabled: false,
         properties: getPropertiesString(itemModel.layout),
       };
-    });
+    }).catch(() => { /* ignore missing library items */ });
   }
 
   return {


### PR DESCRIPTION
to fix problem updating properties (in some cases) for charts with invalid dimension/measures